### PR TITLE
Work around SSLEngine.wrap producing zero bytes.

### DIFF
--- a/core/src/main/scala/org/http4s/blaze/pipeline/stages/SSLStage.scala
+++ b/core/src/main/scala/org/http4s/blaze/pipeline/stages/SSLStage.scala
@@ -183,13 +183,11 @@ final class SSLStage(engine: SSLEngine, maxWrite: Int = 1024 * 1024)
         case HandshakeStatus.NEED_WRAP =>
           val o = getScratchBuffer(maxBuffer)
           val r = engine.wrap(emptyBuffer, o)
+          logger.trace(s"SSL Handshake Status after wrap: $r")
           o.flip()
 
-          if (r.bytesProduced < 1) {
-            logger.warn(s"NEED_WRAP spinning")
-            sslHandshake(data, r.getHandshakeStatus)
-//            handshakeFailure(new SSLException(s"SSL Handshake WRAP produced 0 bytes: $r"))
-          }
+          if (r.bytesProduced < 1 && r.getHandshakeStatus != HandshakeStatus.FINISHED)
+            handshakeFailure(new SSLException(s"SSL Handshake WRAP produced 0 bytes: $r"))
 
           channelWrite(copyBuffer(o)).onComplete {
             case Success(_) => sslHandshake(data, r.getHandshakeStatus)

--- a/core/src/main/scala/org/http4s/blaze/pipeline/stages/SSLStage.scala
+++ b/core/src/main/scala/org/http4s/blaze/pipeline/stages/SSLStage.scala
@@ -185,8 +185,11 @@ final class SSLStage(engine: SSLEngine, maxWrite: Int = 1024 * 1024)
           val r = engine.wrap(emptyBuffer, o)
           o.flip()
 
-          if (r.bytesProduced < 1)
-            handshakeFailure(new SSLException(s"SSL Handshake WRAP produced 0 bytes: $r"))
+          if (r.bytesProduced < 1) {
+            logger.warn(s"NEED_WRAP spinning")
+            sslHandshake(data, r.getHandshakeStatus)
+//            handshakeFailure(new SSLException(s"SSL Handshake WRAP produced 0 bytes: $r"))
+          }
 
           channelWrite(copyBuffer(o)).onComplete {
             case Success(_) => sslHandshake(data, r.getHandshakeStatus)


### PR DESCRIPTION
Error as seen in https://github.com/http4s/http4s/issues/2192, but happens
consistently when running on Google's dataproc service.

Fix inspired by logs posted in https://github.com/netty/netty/issues/1108.
Apparently just invoking wrap multiple times will cause the expected data
to appear in the end.